### PR TITLE
Update apt cache before install packages

### DIFF
--- a/.bonnyci/run.sh
+++ b/.bonnyci/run.sh
@@ -3,6 +3,7 @@
 set -eux
 set -o pipefail
 
+sudo apt-get update
 sudo apt-get install -y python3 python3-dev python3-pip swig portaudio19-dev libpulse-dev pocketsphinx-en-us
 sudo pip3 install tox
 


### PR DESCRIPTION
Make sure the apt cache is up-to-date before installing packages